### PR TITLE
Fix to deal with broken ReelyActive service

### DIFF
--- a/lib/services/reelyactive/index.js
+++ b/lib/services/reelyactive/index.js
@@ -4,7 +4,7 @@ const request = require('request');
 
 const REMOTE_URL = 'https://www.hyperlocalcontext.com/contextat/directory/notman';
 
-/** 
+/**
  * Returns whether the device is 'fixed' to the location. For example
  * the sensors and other devices which are afixed to the building.
  */
@@ -24,15 +24,21 @@ function isFixedDevice(device) {
 
 module.exports.handleGetDeviceDirectory = function(req, res, next) {
     request(REMOTE_URL, function(error, response, body) {
-        console.log('----', body);
-        var deviceData = JSON.parse(body);
-        //console.log(deviceData.devices)
-        for (key in deviceData.devices) {
-            deviceData.devices[key].fixedDevice = isFixedDevice(deviceData.devices[key]);
-            console.log(key)
-        };
+        if (response.statusCode === 200) {
+            var deviceData = JSON.parse(body);
 
-        res.json(deviceData);
+            for (key in deviceData.devices) {
+                deviceData.devices[key].fixedDevice = isFixedDevice(deviceData.devices[key]);
+                console.log(key)
+            };
+
+            res.json(deviceData);
+        } else {
+            res.status(response.statusCode).json({
+                status: response.statusCode,
+                message: `Remote service responded with '${response.statusMessage}'`
+            });
+        }
     });
 
 }


### PR DESCRIPTION
The server hyperlocalcontext.com is returning a 503, which is breaking the API server, since it is assuming a properly formed response. Now handle cases where the server responds with non-200 statuses